### PR TITLE
fix(ui): Remove debug logging handlers from DashboardServerContext

### DIFF
--- a/dashboard-ui/src/contexts/DashboardServerContext.tsx
+++ b/dashboard-ui/src/contexts/DashboardServerContext.tsx
@@ -417,18 +417,6 @@ export const DashboardServerProvider: ParentComponent<DashboardServerProviderPro
         // Store discovered servers in component state or emit event for interested components
         break;
 
-      // TODO: Remove these logging-only handlers post-troubleshooting
-      case 'mcp_catalog_list_response':
-      case 'event_send_response':
-      case 'event_published':
-      case 'subscription_confirmed':
-      case 'organization_list_response':
-      case 'organization_members_response':
-      case 'organization_permissions_response':
-        // These responses are handled by sendMessage promise resolution
-        // Logging cases can be removed once debugging is complete
-        break;
-
       default:
         console.log('🔍 Unhandled dashboard server message type:', message.type);
     }


### PR DESCRIPTION
## Summary
Remove unnecessary no-op case handlers that were only used for debugging.

## Changes
Removed the following debug-only case handlers from `DashboardServerContext.tsx`:
- `mcp_catalog_list_response`
- `event_send_response`
- `event_published`
- `subscription_confirmed`
- `organization_list_response`
- `organization_members_response`
- `organization_permissions_response`

These responses are handled by `sendMessage` promise resolution, so explicit case handlers were unnecessary. The TODO comment even noted these should be removed post-troubleshooting.

## Test plan
- [x] TypeScript compiles without errors
- [x] Change is isolated to removing dead code

## Related Task
Vibe Kanban: `66443974-d955-48db-a47d-09a13b6686e5` - [Low] Debug logging handlers should be removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)