### PR TITLE
fix: Remove artificial setTimeout delays in production code

### DIFF
--- a/dashboard-server/src/websocket/handlers.ts
+++ b/dashboard-server/src/websocket/handlers.ts
@@ -1218,11 +1218,9 @@ async function getMCPServers() {
 }
 
 async function connectMCPServer(serverId: string, serverConfig: any, userContext: UserContext) {
-  // Mock connection for now - in production this would actually configure and connect to the MCP server
+  // TODO: Replace with MCPRegistryHandlers.connectMCPServer() for real DynamoDB persistence
+  // See: dashboard-server/src/handlers/mcpRegistry.ts
   console.log(`Connecting to MCP server ${serverId} for user ${userContext.userId}`);
-
-  // Simulate connection delay
-  await new Promise(resolve => setTimeout(resolve, 1000));
 
   return {
     success: true,

--- a/dashboard-ui/src/components/organization/settings/BillingSettings.tsx
+++ b/dashboard-ui/src/components/organization/settings/BillingSettings.tsx
@@ -170,8 +170,7 @@ export default function BillingSettings() {
 
     try {
       setIsChangingPlan(true);
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      // TODO: Implement real billing API call via WebSocket or Stripe integration
 
       setBillingInfo(prev => ({ ...prev, plan: planId as any }));
 

--- a/dashboard-ui/src/contexts/IntegrationsContext.tsx
+++ b/dashboard-ui/src/contexts/IntegrationsContext.tsx
@@ -301,8 +301,8 @@ export function IntegrationsProvider(props: { children: JSX.Element }) {
 
   const testConnection = async (integrationId: string, connectionId = 'default'): Promise<{ success: boolean; message: string }> => {
     try {
-      // Mock test implementation - in real app would test actual connection
-      await new Promise(resolve => setTimeout(resolve, 1000)); // Simulate API call
+      // TODO: Implement real connection test via WebSocket message to dashboard-server
+      // Should send 'integration:test-connection' message and verify credentials
       success(`Test connection successful for ${integrationId}`);
       return { success: true, message: 'Connection test passed' };
     } catch (err) {


### PR DESCRIPTION
## Summary
Remove unnecessary setTimeout delays that were simulating API calls in mock implementations.

## Changes

| File | Function | Change |
|------|----------|--------|
| `dashboard-server/src/websocket/handlers.ts` | `connectMCPServer()` | Removed 1s delay, added TODO |
| `dashboard-ui/src/contexts/IntegrationsContext.tsx` | `testConnection()` | Removed 1s delay, added TODO |
| `dashboard-ui/src/components/organization/settings/BillingSettings.tsx` | `handlePlanChange()` | Removed 1s delay, added TODO |

## Rationale
These delays served no purpose other than simulating slow API responses. Real implementations should be added when the features are completed. The TODO comments now clearly indicate the need for real implementations.

## Test plan
- [x] TypeScript compiles without errors
- [x] Changes are isolated to removing dead code and adding comments

## Related Task
Vibe Kanban: `cb36df6a-a8a2-45c8-bf52-a2a8d232be23` - [Low] Artificial setTimeout delays in production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)