### PR TITLE
fix(ci): Use consistent Bun version across all workflow jobs

### DIFF
--- a/.github/workflows/dashboard-server-ci.yml
+++ b/.github/workflows/dashboard-server-ci.yml
@@ -129,7 +129,7 @@ jobs:
     - name: Setup Bun
       uses: oven-sh/setup-bun@v1
       with:
-        bun-version: 'latest'
+        bun-version: '1.2.22'
 
     - name: Install dependencies
       run: |
@@ -186,7 +186,7 @@ jobs:
     - name: Setup Bun
       uses: oven-sh/setup-bun@v1
       with:
-        bun-version: 'latest'
+        bun-version: '1.2.22'
 
     - name: Install dependencies
       run: |
@@ -237,7 +237,7 @@ jobs:
     - name: Setup Bun
       uses: oven-sh/setup-bun@v1
       with:
-        bun-version: 'latest'
+        bun-version: '1.2.22'
 
     - name: Install Rust (for use_aws_mcp)
       uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
Pin all workflow jobs to Bun 1.2.22 instead of mixing pinned and 'latest' versions.

## Changes
| Job | Before | After |
|-----|--------|-------|
| test | `1.2.22` | `1.2.22` ✓ |
| security | `latest` | `1.2.22` |
| build | `latest` | `1.2.22` |
| mcp-integration | `latest` | `1.2.22` |

## Why This Matters
Using `latest` for some jobs while others are pinned to `1.2.22` can cause:
- Inconsistent builds between jobs
- "Works on CI" bugs when `latest` bumps unexpectedly
- Lockfile conflicts if different Bun versions generate different lockfiles

## Test plan
- [ ] All workflow jobs use the same Bun version
- [ ] CI passes with consistent versions

## Related Task
Vibe Kanban: `7b8629f5-8b5c-42aa-8d6c-5dd0b24de10e` - [Medium] Inconsistent Bun versions in CI workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)