### PR TITLE
fix: Remove duplicate Contributing section and add check:test-debt script

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,18 +187,15 @@ Form Submission → Data Enrichment → Compliance Check → Manual Review → A
 
 ## Contributing
 
-See [CLAUDE.md](CLAUDE.md) for development guidelines and setup instructions.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines and [CLAUDE.md](CLAUDE.md) for development setup instructions.
 
 ## Documentation
 
 - [`CLAUDE.md`](CLAUDE.md) - Complete codebase overview and architecture
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) - Contribution guidelines
 - [`mcp-rust/`](mcp-rust/README.md) - MCP server documentation
 - [`.claude/`](.claude/README.md) - Agent orchestration system
 - [`infra/`](infra/) - Terraform infrastructure modules
-
-## Contributing
-
-See [CLAUDE.md](CLAUDE.md) for development guidelines.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "tf:destroy": "cd infra/workspaces/${WS:-small/kv_store} && terraform destroy -auto-approve -var env=${ENV:-dev}",
     "install:hooks": "bash scripts/install-hooks.sh",
     "ui:test": "npm run test --workspace=dashboard-ui",
+    "server:test": "npm run test --workspace=dashboard-server",
+    "check:test-debt": "! grep -r '\\.skip\\|it\\.skip\\|describe\\.skip\\|test\\.skip' dashboard-ui/src dashboard-server/src --include='*.test.*' --include='*.spec.*' 2>/dev/null || echo 'No skipped tests found'",
     "test:all": "npm run test --workspace=dashboard-server && npm run test --workspace=dashboard-ui && npm run check:test-debt"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
Fix two documentation/configuration issues in the repository.

## Changes

### README.md
- Remove duplicate Contributing section (was at lines 188 and 199)
- Consolidate into single section linking to both CONTRIBUTING.md and CLAUDE.md
- Add CONTRIBUTING.md to documentation list

### package.json
- Add missing `check:test-debt` script that `test:all` depends on
- Script checks for `.skip` patterns in test files to catch test debt
- Add `server:test` script for consistency with `ui:test`

## Test plan
- [x] `npm run check:test-debt` executes without error
- [x] README has single Contributing section

## Related Tasks
- Vibe Kanban: `36a92f19-0847-44e7-8bc8-7c790e9298b3` - [Medium] Duplicate Contributing sections in README.md
- Vibe Kanban: `457aafa7-8de3-4a7e-a7bc-56161e1b82cd` - [Medium] Missing check:test-debt npm script

🤖 Generated with [Claude Code](https://claude.com/claude-code)