### PR TITLE
fix: Update cost estimates, restrict IAM policy, add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- CHANGELOG.md file for tracking changes
+
+### Changed
+- Updated workspace tier cost estimates to match infrastructure documentation
+- Restricted CloudWatch Logs IAM policy to specific log group (security fix)
+
+### Security
+- Fixed overly permissive CloudWatch Logs IAM policy (`resources = ["*"]` -> specific ARN)
+
+## [2.1.0] - 2026-01-07
+
+### Added
+- Comprehensive CONTRIBUTING.md with development guidelines (#17)
+- SECURITY.md with vulnerability reporting process (#20)
+- MCP-Rust documentation (API, Architecture, Deployment, Migration guides)
+- SNS integration for notifications (#16)
+- Wait-for-server retry logic in CI for flaky test prevention (#24)
+- Terraform plugin cache to prevent CI disk space exhaustion (#22)
+
+### Changed
+- Migrated from Node.js MCP server to Rust implementation (#21)
+- Updated docker-compose.test.yml to reference mcp-rust (#20)
+
+### Fixed
+- Replaced hardcoded demo-user IDs with auth context (#23)
+- Implemented event rule actions (SNS, webhook, workflow triggers) (#19)
+- Removed all 9 skipped tests in dashboard-ui (#15)
+- Removed hardcoded JWT secret fallback, require JWT_SECRET in production (#13)
+- Fixed useAutoSave race condition to prevent data loss (#12)
+
+### Security
+- Multi-agent security hardening (#16)
+- Store integration credentials in AWS Secrets Manager instead of DynamoDB (#10)
+- Password validation UI components with strength indicators (#16)
+- AES-256-GCM encryption for credentials (#16)
+
+## [2.0.0] - 2026-01-01
+
+### Added
+- Full infrastructure as code with Terraform workspaces (extra-small, small, medium, large)
+- MCP Rust server implementation with multi-tenant support
+- Dashboard UI with SolidJS
+- Dashboard Server with WebSocket-first architecture
+- Google Analytics integration
+- AWS Bedrock chat integration
+- Yjs workflow persistence to DynamoDB/S3 (#9)
+- Feature flags system (#4)
+- AI-powered workflow generation with persistent chat history
+
+### Changed
+- Reorganized documentation into structured folders
+- Made getServerForTool data-driven instead of giant if-statement
+- Converted dashboard-server reports to TypeScript (#7)
+
+### Fixed
+- Tool routing for kv_*, events_*, artifacts_* to aws MCP server
+- Dark mode hover class in SidebarSettings
+- Chat service and uploads issues
+
+## [1.0.0] - Initial Release
+
+### Added
+- Initial Agent Mesh MCP Server
+- Core AWS integrations (DynamoDB, S3, EventBridge, Secrets Manager)
+- Basic workflow execution engine
+- Multi-tenant architecture foundation

--- a/dashboard-ui/src/types/workspaceTiers.ts
+++ b/dashboard-ui/src/types/workspaceTiers.ts
@@ -74,7 +74,7 @@ export const TIER_CONFIGS: Record<WorkspaceTier, TierCapabilities> = {
     tier: WorkspaceTier.EXTRA_SMALL,
     displayName: 'Extra Small',
     description: 'Minimal infrastructure for testing',
-    monthlyEstimate: '~$5/month',
+    monthlyEstimate: '~$10/month',
 
     modules: {
       kvStore: false,
@@ -110,7 +110,7 @@ export const TIER_CONFIGS: Record<WorkspaceTier, TierCapabilities> = {
     tier: WorkspaceTier.SMALL,
     displayName: 'Small',
     description: 'Basic AWS components for simple workflows',
-    monthlyEstimate: '~$10/month',
+    monthlyEstimate: '~$15-20/month',
 
     modules: {
       kvStore: true,
@@ -146,7 +146,7 @@ export const TIER_CONFIGS: Record<WorkspaceTier, TierCapabilities> = {
     tier: WorkspaceTier.MEDIUM,
     displayName: 'Medium',
     description: 'ECS agents, workflows, and observability',
-    monthlyEstimate: '~$100/month',
+    monthlyEstimate: '~$50-80/month',
 
     modules: {
       kvStore: true,
@@ -182,7 +182,7 @@ export const TIER_CONFIGS: Record<WorkspaceTier, TierCapabilities> = {
     tier: WorkspaceTier.LARGE,
     displayName: 'Large',
     description: 'Full platform with vector database',
-    monthlyEstimate: '~$1000/month',
+    monthlyEstimate: '~$200-400/month',
 
     modules: {
       kvStore: true,

--- a/infra/modules/ecs_dashboard_service/main.tf
+++ b/infra/modules/ecs_dashboard_service/main.tf
@@ -139,7 +139,8 @@ data "aws_iam_policy_document" "task_role_policy" {
     resources = [var.secrets_arn]
   }
 
-  # CloudWatch Logs (minimal for cost control)
+  # CloudWatch Logs - restricted to this service's log group only
+  # Security: Do not use "*" - it grants access to ALL log groups in the account
   statement {
     sid    = "CloudWatchLogs"
     effect = "Allow"
@@ -147,7 +148,7 @@ data "aws_iam_policy_document" "task_role_policy" {
       "logs:CreateLogStream",
       "logs:PutLogEvents"
     ]
-    resources = ["*"]
+    resources = ["${aws_cloudwatch_log_group.dashboard.arn}:*"]
   }
 }
 


### PR DESCRIPTION
## Summary
- Updated workspace tier cost estimates in `workspaceTiers.ts` to match infrastructure documentation
- Fixed overly permissive CloudWatch Logs IAM policy (security fix)
- Created CHANGELOG.md following Keep a Changelog format

## Changes

### Cost Estimates (workspaceTiers.ts)
| Tier | Old | New |
|------|-----|-----|
| extra-small | ~$5/month | ~$10/month |
| small | ~$10/month | ~$15-20/month |
| medium | ~$100/month | ~$50-80/month |
| large | ~$1000/month | ~$200-400/month |

### IAM Security Fix (ecs_dashboard_service/main.tf)
Changed CloudWatch Logs IAM policy from:
```hcl
resources = ["*"]
```
To:
```hcl
resources = ["${aws_cloudwatch_log_group.dashboard.arn}:*"]
```

This restricts the ECS task to only write logs to its own log group, following least-privilege principle.

### CHANGELOG.md
Created comprehensive changelog documenting:
- v1.0.0 - Initial release
- v2.0.0 - Major infrastructure and feature additions
- v2.1.0 - Recent PRs #9-24
- Unreleased - Current changes

## Test plan
- [ ] Verify cost estimates display correctly in dashboard UI
- [ ] Verify Terraform plan shows expected IAM policy change
- [ ] Verify CHANGELOG follows Keep a Changelog format

🤖 Generated with [Claude Code](https://claude.com/claude-code)