### PR TITLE
fix: Prevent memory leak from uncleaned setInterval in EventsHandler

### DIFF
--- a/dashboard-server/src/handlers/events.ts
+++ b/dashboard-server/src/handlers/events.ts
@@ -50,9 +50,38 @@ export interface EventRuleAction {
 export class EventsHandler {
   private static subscribers = new Map<string, EventSubscription>();
   private static mcpService: MCPStdioService | null = null;
+  private static cleanupInterval: ReturnType<typeof setInterval> | null = null;
 
   static initialize(mcpService: MCPStdioService) {
     this.mcpService = mcpService;
+    // Start cleanup interval if not already running
+    if (!this.cleanupInterval) {
+      this.startCleanupInterval();
+    }
+  }
+
+  /**
+   * Start the cleanup interval for closed connections
+   */
+  private static startCleanupInterval(): void {
+    this.cleanupInterval = setInterval(() => {
+      this.cleanup();
+    }, 30000); // Every 30 seconds
+  }
+
+  /**
+   * Shutdown the events handler and cleanup resources
+   * Call this during graceful shutdown to prevent memory leaks
+   */
+  static shutdown(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = null;
+    }
+    // Close all subscriptions
+    this.subscribers.clear();
+    this.mcpService = null;
+    console.log('🔌 EventsHandler shutdown complete');
   }
 
   /**
@@ -532,10 +561,5 @@ export class EventsHandler {
     };
   }
 }
-
-// Start cleanup interval
-setInterval(() => {
-  EventsHandler.cleanup();
-}, 30000); // Every 30 seconds
 
 export default EventsHandler;

--- a/dashboard-server/src/websocket/handlers.ts
+++ b/dashboard-server/src/websocket/handlers.ts
@@ -160,6 +160,8 @@ export function setupWebSocketHandlers(wss: WebSocketServer, { metricsAggregator
     cleanup: async () => {
       // Cleanup agent handler MCP connection
       await AgentHandler.cleanup();
+      // Shutdown events handler (cleanup interval timer)
+      EventsHandler.shutdown();
     }
   };
 }


### PR DESCRIPTION
## Summary
- Fixed memory leak caused by `setInterval` created at module load but never cleared
- EventsHandler now properly manages its cleanup interval lifecycle

## Problem
```javascript
// Before: Global interval at module load, never cleared
setInterval(() => {
  EventsHandler.cleanup();
}, 30000);
```

The interval continued running even after server shutdown, preventing proper garbage collection.

## Solution
```javascript
// After: Interval managed with proper lifecycle
export class EventsHandler {
  private static cleanupInterval: ReturnType<typeof setInterval> | null = null;

  static initialize(mcpService: MCPStdioService) {
    // Start interval only when initialized
    if (!this.cleanupInterval) {
      this.startCleanupInterval();
    }
  }

  static shutdown(): void {
    if (this.cleanupInterval) {
      clearInterval(this.cleanupInterval);
      this.cleanupInterval = null;
    }
    this.subscribers.clear();
  }
}
```

## Changes
- Added `cleanupInterval` static property to store interval reference
- Moved interval creation into `initialize()` method
- Added `shutdown()` method to clear interval and cleanup state
- Called `EventsHandler.shutdown()` during graceful server shutdown in `handlers.ts`

## Test plan
- [ ] Verify server starts normally
- [ ] Verify cleanup runs every 30 seconds (check logs)
- [ ] Verify server shuts down cleanly with SIGTERM/SIGINT
- [ ] Verify no lingering intervals after shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)