### PR TITLE
feat: Add docker-compose.yml for local development environment

### DIFF
--- a/dashboard-ui/Dockerfile.dev
+++ b/dashboard-ui/Dockerfile.dev
@@ -1,0 +1,19 @@
+# Development Dockerfile for Dashboard UI
+# Uses Vite dev server with hot module replacement
+
+FROM oven/bun:1.2.22-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile
+
+# Copy source files (will be overridden by volume mount for hot reload)
+COPY . .
+
+# Expose Vite dev server port
+EXPOSE 5173
+
+# Start Vite dev server with host binding for Docker
+CMD ["bun", "run", "dev", "--host", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,186 @@
+# Development Environment for AWS AI Agent Bus
+#
+# Usage:
+#   docker-compose up -d              # Start all services
+#   docker-compose up -d localstack   # Start only LocalStack
+#   docker-compose logs -f dashboard-server  # Follow dashboard-server logs
+#   docker-compose down -v            # Stop and remove volumes
+#
+# Services:
+#   - localstack: Local AWS (DynamoDB, S3, EventBridge, Secrets Manager)
+#   - dashboard-server: Bun-based API server (port 3001)
+#   - dashboard-ui: Vite dev server (port 5173)
+#   - mcp-rust: Rust MCP server (optional, for local testing)
+
+version: '3.8'
+
+services:
+  # LocalStack for AWS services emulation
+  localstack:
+    container_name: agent-mesh-localstack-dev
+    image: localstack/localstack:3.0
+    ports:
+      - "4566:4566"            # LocalStack Gateway
+      - "4510-4559:4510-4559"  # External services port range
+    environment:
+      - SERVICES=dynamodb,s3,events,secretsmanager,stepfunctions,logs
+      - DEBUG=${LOCALSTACK_DEBUG:-0}
+      - PERSISTENCE=1
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - localstack-data:/var/lib/localstack
+      - /var/run/docker.sock:/var/run/docker.sock
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+    networks:
+      - agent-mesh-dev
+
+  # Dashboard Server (Bun)
+  dashboard-server:
+    build:
+      context: ./dashboard-server
+      dockerfile: Dockerfile
+    container_name: agent-mesh-dashboard-server
+    ports:
+      - "3001:3001"
+    environment:
+      # AWS LocalStack Configuration
+      - AWS_ENDPOINT_URL=http://localstack:4566
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
+      - AWS_REGION=us-east-1
+      # Server Configuration
+      - NODE_ENV=development
+      - DASHBOARD_PORT=3001
+      - ENABLE_DEV_AUTH=true
+      # Agent Mesh Configuration
+      - AGENT_MESH_ENV=dev
+      - AGENT_MESH_KV_TABLE=agent-mesh-kv
+      - AGENT_MESH_ARTIFACTS_BUCKET=agent-mesh-artifacts
+      - AGENT_MESH_EVENT_BUS=agent-mesh-events
+      - AGENT_MESH_TIMELINE_BUCKET=agent-mesh-timeline
+      # MCP Server (embedded or external)
+      - MCP_SERVER_BINARY=/app/bin/mcp-server
+    depends_on:
+      localstack:
+        condition: service_healthy
+    volumes:
+      # Mount source for hot reload (optional - remove for production-like testing)
+      - ./dashboard-server/src:/app/src:ro
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    networks:
+      - agent-mesh-dev
+
+  # Dashboard UI (Vite dev server)
+  dashboard-ui:
+    build:
+      context: ./dashboard-ui
+      dockerfile: Dockerfile.dev
+      args:
+        - NODE_ENV=development
+    container_name: agent-mesh-dashboard-ui
+    ports:
+      - "5173:5173"
+    environment:
+      - NODE_ENV=development
+      - VITE_ENABLE_DEV_AUTH=true
+      - VITE_DEV_MODE=true
+      - VITE_MCP_SERVER_URL=http://localhost:3001
+      - VITE_DASHBOARD_SERVER_URL=ws://dashboard-server:3001
+      - VITE_SHOW_DEBUG_INFO=true
+    volumes:
+      # Mount source for hot reload
+      - ./dashboard-ui/src:/app/src:ro
+      - ./dashboard-ui/index.html:/app/index.html:ro
+    depends_on:
+      - dashboard-server
+    networks:
+      - agent-mesh-dev
+
+  # Rust MCP Server (optional - for standalone MCP testing)
+  mcp-rust:
+    build:
+      context: ./mcp-rust
+      dockerfile: Dockerfile.build
+    container_name: agent-mesh-mcp-rust
+    profiles:
+      - mcp  # Only starts with: docker-compose --profile mcp up
+    environment:
+      - AWS_ENDPOINT_URL=http://localstack:4566
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
+      - AWS_REGION=us-east-1
+      - RUST_LOG=info
+      - AGENT_MESH_KV_TABLE=agent-mesh-kv
+      - AGENT_MESH_ARTIFACTS_BUCKET=agent-mesh-artifacts
+      - AGENT_MESH_EVENT_BUS=agent-mesh-events
+    depends_on:
+      localstack:
+        condition: service_healthy
+    networks:
+      - agent-mesh-dev
+
+  # LocalStack Initializer (creates tables, buckets, etc.)
+  localstack-init:
+    image: amazon/aws-cli:latest
+    container_name: agent-mesh-localstack-init
+    depends_on:
+      localstack:
+        condition: service_healthy
+    environment:
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
+      - AWS_DEFAULT_REGION=us-east-1
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        echo "Initializing LocalStack resources..."
+
+        # DynamoDB Tables
+        aws --endpoint-url=http://localstack:4566 dynamodb create-table \
+          --table-name agent-mesh-kv \
+          --attribute-definitions AttributeName=PK,AttributeType=S AttributeName=SK,AttributeType=S \
+          --key-schema AttributeName=PK,KeyType=HASH AttributeName=SK,KeyType=RANGE \
+          --billing-mode PAY_PER_REQUEST \
+          || echo "Table agent-mesh-kv may already exist"
+
+        aws --endpoint-url=http://localstack:4566 dynamodb create-table \
+          --table-name agent-mesh-events \
+          --attribute-definitions AttributeName=PK,AttributeType=S AttributeName=SK,AttributeType=S \
+          --key-schema AttributeName=PK,KeyType=HASH AttributeName=SK,KeyType=RANGE \
+          --billing-mode PAY_PER_REQUEST \
+          || echo "Table agent-mesh-events may already exist"
+
+        # S3 Buckets
+        aws --endpoint-url=http://localstack:4566 s3 mb s3://agent-mesh-artifacts \
+          || echo "Bucket agent-mesh-artifacts may already exist"
+
+        aws --endpoint-url=http://localstack:4566 s3 mb s3://agent-mesh-timeline \
+          || echo "Bucket agent-mesh-timeline may already exist"
+
+        # EventBridge Event Bus
+        aws --endpoint-url=http://localstack:4566 events create-event-bus \
+          --name agent-mesh-events \
+          || echo "Event bus agent-mesh-events may already exist"
+
+        echo "LocalStack initialization complete!"
+    networks:
+      - agent-mesh-dev
+
+networks:
+  agent-mesh-dev:
+    name: agent-mesh-dev
+    driver: bridge
+
+volumes:
+  localstack-data:
+    name: agent-mesh-localstack-data


### PR DESCRIPTION
## Summary
- Adds complete Docker Compose development environment
- LocalStack for AWS service emulation
- Hot reload support for both dashboard-server and dashboard-ui

## Services

| Service | Port | Description |
|---------|------|-------------|
| `localstack` | 4566 | AWS services (DynamoDB, S3, EventBridge, Secrets) |
| `dashboard-server` | 3001 | Bun-based API server |
| `dashboard-ui` | 5173 | Vite dev server with HMR |
| `mcp-rust` | - | Optional MCP server (use --profile mcp) |
| `localstack-init` | - | One-time resource initializer |

## Usage

```bash
# Start all services
docker-compose up -d

# Start only LocalStack (for local bun dev)
docker-compose up -d localstack localstack-init

# Include MCP Rust server
docker-compose --profile mcp up -d

# View logs
docker-compose logs -f dashboard-server

# Stop and cleanup
docker-compose down -v
```

## New Files
- `docker-compose.yml` - Main development compose file
- `dashboard-ui/Dockerfile.dev` - Vite dev server Dockerfile

## Features
- Health checks ensure proper service ordering
- Persistent LocalStack data via named volume
- Volume mounts for hot reload during development
- Isolated network separate from test environment

## Test plan
- [ ] `docker-compose up -d` starts all services
- [ ] Dashboard UI accessible at http://localhost:5173
- [ ] Dashboard Server health check at http://localhost:3001/health
- [ ] LocalStack tables/buckets created by init container

🤖 Generated with [Claude Code](https://claude.com/claude-code)